### PR TITLE
Fixed interval scoping issue in tap gesture recognizer for multiple taps

### DIFF
--- a/packages/sproutcore-touch/lib/gesture_recognizers/tap.js
+++ b/packages/sproutcore-touch/lib/gesture_recognizers/tap.js
@@ -80,7 +80,11 @@ SC.TapGestureRecognizer = SC.Gesture.extend({
 
     if (get(this.touches,'length') < get(this, 'numberOfTaps')) {
       this._waitingForMoreTouches = true;
-      this._waitingInterval = window.setInterval(this._intervalFired,this.MULTITAP_DELAY);
+
+      var self = this;
+      this._waitingInterval = window.setInterval(function() {
+        self._intervalFired();
+      }, this.MULTITAP_DELAY);
     }
   },
 
@@ -107,7 +111,7 @@ SC.TapGestureRecognizer = SC.Gesture.extend({
 
   _intervalFired: function() {
     window.clearInterval(this._waitingInterval);
-    _waitingForMoreTouches = false;
+    this._waitingForMoreTouches = false;
   }
 });
 


### PR DESCRIPTION
The interval running `this._intervalFired` attached to `window` was never cleared, nor did it set the `_waitingForMoreTouches` to false.

I'm not much of a JS sorcerer, so you may find a more elegant solution. Seems that is solves the problem though.
